### PR TITLE
Fix problem with 12h format timestamp

### DIFF
--- a/app/publish-snapshot.js
+++ b/app/publish-snapshot.js
@@ -13,7 +13,7 @@ module.exports = {
 
     addDateToVersion: function (appConfig) {
 
-        var now = moment().format('YYYYMMDD.hhmmss');
+        var now = moment().format('YYYYMMDD.HHmmss');
         appConfig.packageJson.version = appConfig.packageJson.version + "." + now;
         fs.writeFileSync('package.json', JSON.stringify(appConfig.packageJson, null, 2));
     }


### PR DESCRIPTION
12 at night will always be latest snapshot, but should not