### PR TITLE
Exit shell with 1 when something fails during npm publish

### DIFF
--- a/app/commands.js
+++ b/app/commands.js
@@ -2,6 +2,7 @@ var fs = require('fs-extra');
 var pr = require('properties-reader');
 var commander = require('commander');
 var log = require('module-log');
+var shell = require('shelljs');
 
 var tag = require('./create-tag');
 var release = require('./publish-release');
@@ -64,16 +65,21 @@ module.exports = {
     deploy: function () {
         this.verify();
         this.backup();
+        var shellExitCode = 0;
         if (commander.release) {
             tag.createTag(this.appConfig, this.config.tag, this.message);
-            release.publishRelease(this.appConfig.packageJson.distributionManagement.releaseRegistry);
+            shellExitCode = release.publishRelease(this.appConfig.packageJson.distributionManagement.releaseRegistry);
             release.updatePkgVersion(this.appConfig, this.message);
             rollback.clean();
         } else {
             snapshot.addDateToVersion(this.appConfig);
-            snapshot.publishSnapshot(this.appConfig.packageJson.distributionManagement.snapshotRegistry);
+            shellExitCode = snapshot.publishSnapshot(this.appConfig.packageJson.distributionManagement.snapshotRegistry);
             rollback.rollback();
         }
+        if(shellExecCode !== 0) {
+			shell.echo("Error: npm publish failed.")
+			shell.exit(shellExitCode);
+		}
     },
     clean: function () {
         rollback.clean();

--- a/app/publish-release.js
+++ b/app/publish-release.js
@@ -5,7 +5,7 @@ var log = require('module-log');
 module.exports = {
     publishRelease: function (releaseRegistry) {
         log.debug('publish release');
-        shell.exec('npm publish --registry=' + releaseRegistry);
+        return shell.exec('npm publish --registry=' + releaseRegistry).code;
     },
     updatePkgVersion: function (appConfig, message) {
         var versionArray = appConfig.packageJson.version.split('.');

--- a/app/publish-snapshot.js
+++ b/app/publish-snapshot.js
@@ -6,7 +6,7 @@ var log = require('module-log');
 module.exports = {
     publishSnapshot: function (snapshotRepository) {
         log.info('publish snapshot => ' + snapshotRepository);
-        shell.exec('npm publish --registry=' + snapshotRepository);
+        return shell.exec('npm publish --registry=' + snapshotRepository).code;
     },
 
     addDateToVersion: function (appConfig) {


### PR DESCRIPTION
I use this plugin in maven builds. But the tools does not exit with an return code when something went wrong. This way maven build would always be successful even if npm publish fails.
So I added a check if the shell exec code is !=0 and exit the shell so maven can handle it and fails the build.